### PR TITLE
fix: handle multiple dashes in company name

### DIFF
--- a/src/EventSubscriber/Serialization/JMS/ShipmentNormalizer.php
+++ b/src/EventSubscriber/Serialization/JMS/ShipmentNormalizer.php
@@ -54,20 +54,20 @@ class ShipmentNormalizer implements EventSubscriberInterface
 
         $shippingAddress = $shipment->getOrder()->getShippingAddress();
 
-        list ($company, $parcelId) = explode(
+        list ($parcelId, $company) = explode(
             ShippingMethodChoiceTypeExtension::SEPARATOR_PARCEL_NAME_AND_PARCEL_ID,
-            \is_string($shippingAddress->getCompany()) ? $shippingAddress->getCompany() : ''
+            \is_string($shippingAddress->getCompany()) ? strrev($shippingAddress->getCompany()) : ''
         );
 
         $data = [
             'shipping_code' => $this->configuration->getShippingCode(),
             'place_code' => $this->configuration->getPlaceCode(),
-            'parcel_point_id' => $parcelId,
+            'parcel_point_id' => $parcelId ? strrev($parcelId) : $parcelId,
             'parcel' => [
                 'street' => $shippingAddress->getStreet(),
                 'postcode' => $shippingAddress->getPostcode(),
                 'city' => $shippingAddress->getCity(),
-                'company' => $company,
+                'company' => $company ? strrev($company) : $company,
             ],
         ];
 

--- a/tests/EventSubscriber/Serialization/JMS/ShipmentNormalizerTest.php
+++ b/tests/EventSubscriber/Serialization/JMS/ShipmentNormalizerTest.php
@@ -173,6 +173,33 @@ class ShipmentNormalizerTest extends TestCase
                 'company' => 'Wishi shoes store',
             ],
         ], $data);
+
+        $address->setCompany('Wishi shoes store----P-123141');
+        $order->getShippingAddress()->willReturn($address);
+        $this->configuration->getMondialRelayCode()->willReturn('12');
+        $this->configuration->getPlaceCode()->willReturn('B1');
+        $this->configuration->getShippingCode()->willReturn('24R');
+        $shipment->getOrder()->willReturn($order->reveal());
+        $objectEvent->getObject()->willReturn($shipment->reveal());
+
+        $this->subject->onPostSerialize($objectEvent->reveal());
+
+        $data = Reflection::getPrivateProperty($this->visitor, 'data');
+        $this->assertNotNull($data);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('mondial_relay_data', $data);
+        $data = $data['mondial_relay_data'];
+        $this->assertEquals([
+            'shipping_code' => '24R',
+            'place_code' => 'B1',
+            'parcel_point_id' => 'P-123141',
+            'parcel' => [
+                'street' => '42 rue des fleurs',
+                'postcode' => '12345',
+                'city' => 'Wishiland',
+                'company' => 'Wishi shoes store-',
+            ],
+        ], $data);
     }
 
     public function notAShipmentDataProvider()


### PR DESCRIPTION
Ticket : https://trello.com/c/hQ0jVUjA/327-mondialrelay-code-erreur-70

Certains noms de company sur mondial relay finissent par un tiret : `LOCKER 24/7 UTILE ARGENTRE-DU-`.
Stocké en DB avec le parcelId ça devient : `LOCKER 24/7 UTILE ARGENTRE-DU----FR-017983`

Le `explode` va donc explosé au niveau de la première occurence de `---`. Le parcelId dans ce cas sera `-FR-017983`.

Ici, l'utilisation de `strrev` inverse la chaine de caractère, ce qui donnera le bon résultat:
 `parcelId => FR-017983`
 `company => LOCKER 24/7 UTILE ARGENTRE-DU-`