### PR TITLE
:sparkles: clear session after address is changed explicitely

### DIFF
--- a/src/Form/EventSubscriber/ForgetPreviousAddressOnAddressFormValidationSubscriber.php
+++ b/src/Form/EventSubscriber/ForgetPreviousAddressOnAddressFormValidationSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ForgetPreviousAddressOnAddressFormValidationSubscriber implements EventSubscriberInterface
+{
+    private SessionInterface $session;
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::POST_SUBMIT => 'forgetPreviousAddress',
+        ];
+    }
+
+    public function forgetPreviousAddress(FormEvent $event): void
+    {
+        $this->session->set(SetMondialRelayParcelPointOnShippingAddressSubscriber::SESSION_ID, null);
+    }
+}

--- a/src/Form/EventSubscriber/SetMondialRelayParcelPointOnShippingAddressSubscriber.php
+++ b/src/Form/EventSubscriber/SetMondialRelayParcelPointOnShippingAddressSubscriber.php
@@ -14,8 +14,11 @@ use Wishibam\SyliusMondialRelayPlugin\Form\Extension\ShippingMethodChoiceTypeExt
 
 class SetMondialRelayParcelPointOnShippingAddressSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private SessionInterface $session)
+    public const SESSION_ID = 'mondialRelayPreviousAddress';
+    private SessionInterface $session;
+    public function __construct(SessionInterface $session)
     {
+        $this->session = $session;
     }
     public static function getSubscribedEvents()
     {
@@ -56,7 +59,7 @@ class SetMondialRelayParcelPointOnShippingAddressSubscriber implements EventSubs
 
     private function saveAddressData(Address $address)
     {
-        $this->session->set('mondialRelayPreviousAddress', [
+        $this->session->set(self::SESSION_ID, [
             'postCode' => $address->getPostcode(),
             'street' => $address->getStreet(),
             'city' => $address->getCity(),
@@ -67,7 +70,7 @@ class SetMondialRelayParcelPointOnShippingAddressSubscriber implements EventSubs
     private function resetAddress(Address $address)
     {
         /** @var null|array{postCode: ?string, street: ?string, city: ?string, company: ?string} $previousAddress */
-        $previousAddress = $this->session->get('mondialRelayPreviousAddress');
+        $previousAddress = $this->session->get(self::SESSION_ID);
 
         if (null === $previousAddress) {
             return;

--- a/src/Form/Extension/AddressTypeExtension.php
+++ b/src/Form/Extension/AddressTypeExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wishibam\SyliusMondialRelayPlugin\Form\Extension;
+
+use Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber\ForgetPreviousAddressOnAddressFormValidationSubscriber;
+
+class AddressTypeExtension extends AbstractTypeExtension
+{
+    private SessionInterface $session;
+
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addEventSubscriber(new ForgetPreviousAddressOnAddressFormValidationSubscriber($this->session));
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [AddressType::class];
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,6 +10,14 @@ services:
         tags:
             - { name: 'form.type_extension' }
 
+    wishibam.mondial_relay.form.forget_previous_address:
+        class: Wishibam\SyliusMondialRelayPlugin\Form\Extension\AddressTypeExtension
+        public: false
+        arguments:
+            $session: '@session'
+        tags:
+            - { name: 'form.type_extension' }
+
     wishibam.mondial_relay.serialization.shipment:
         class: Wishibam\SyliusMondialRelayPlugin\EventSubscriber\Serialization\JMS\ShipmentNormalizer
         arguments:

--- a/tests/Form/EventSubscriber/ForgetPreviousAddressOnAddressFormValidationSubscriberTest.php
+++ b/tests/Form/EventSubscriber/ForgetPreviousAddressOnAddressFormValidationSubscriberTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber\ForgetPreviousAddressOnAddressFormValidationSubscriber;
+use Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber\SetMondialRelayParcelPointOnShippingAddressSubscriber;
+
+class ForgetPreviousAddressOnAddressFormValidationSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+    public function testItClearSessionOnFormSubmit()
+    {
+        $session = $this->prophesize(SessionInterface::class);
+        $this->assertArrayHasKey(FormEvents::POST_SUBMIT, ForgetPreviousAddressOnAddressFormValidationSubscriber::getSubscribedEvents());
+        $session->set(SetMondialRelayParcelPointOnShippingAddressSubscriber::SESSION_ID, null)->shouldBeCalled();
+
+        $listener = new ForgetPreviousAddressOnAddressFormValidationSubscriber($session->reveal());
+        $listener->forgetPreviousAddress($this->prophesize(FormEvent::class)->reveal());
+    }
+
+}

--- a/tests/Form/Extension/AddressTypeExtensionTest.php
+++ b/tests/Form/Extension/AddressTypeExtensionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Wishibam\SyliusMondialRelayPlugin\Form\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Wishibam\SyliusMondialRelayPlugin\Form\Extension\AddressTypeExtension;
+
+class AddressTypeExtensionTest extends TestCase
+{
+    use ProphecyTrait;
+    public function testItAddsSubscriberToAddressType()
+    {
+        $this->assertTrue(in_array(AddressType::class, AddressTypeExtension::getExtendedTypes()));
+        $extension = new AddressTypeExtension($this->prophesize(SessionInterface::class)->reveal());
+
+        $builder = $this->prophesize(FormBuilderInterface::class);
+        $builder->addEventSubscriber(Argument::cetera())->shouldBeCalled();
+        $extension->buildForm($builder->reveal(), []);
+    }
+}

--- a/tests/Form/Extension/ShippingMethodChoiceTypeExtensionTest.php
+++ b/tests/Form/Extension/ShippingMethodChoiceTypeExtensionTest.php
@@ -20,6 +20,7 @@ use Sylius\Component\Shipping\Model\ShippingMethod;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Wishibam\SyliusMondialRelayPlugin\DependencyInjection\ParsedConfiguration;
 use Wishibam\SyliusMondialRelayPlugin\Form\EventSubscriber\SetMondialRelayParcelPointOnShippingAddressSubscriber;
 use Wishibam\SyliusMondialRelayPlugin\Form\Extension\ShippingMethodChoiceTypeExtension;
@@ -145,7 +146,12 @@ class ShippingMethodChoiceTypeExtensionTest extends TypeTestCase
             ['type' => 'leaflet'],
             true
         );
-        $subject = new ShippingMethodChoiceTypeExtension($this->shippingMethodResolver->reveal(), $this->repository->reveal(), $this->configuration);
+        $subject = new ShippingMethodChoiceTypeExtension(
+            $this->shippingMethodResolver->reveal(),
+            $this->repository->reveal(),
+            $this->configuration,
+            $this->prophesize(SessionInterface::class)->reveal()
+        );
 
         return [
             $subject,


### PR DESCRIPTION
1. I set an address
2. I choose mondial relay
3. I go back to address and change it
4. I choose something else than mondial relay
5. The change previously done on address should not be override by the address previously set in mondial relay