### PR TITLE
fix: prevent pickup points parsing exceptions

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -22,6 +22,7 @@ services:
         class: Wishibam\SyliusMondialRelayPlugin\EventSubscriber\Serialization\JMS\ShipmentNormalizer
         arguments:
             $configurationResolver: '@wishibam_mondial_relay.configuration_resolver'
+            $logger: '@logger'
         tags:
             - { name: 'jms_serializer.event_subscriber' }
 


### PR DESCRIPTION
- **Sentry:** https://wishibam.sentry.io/issues/3684806469

## Descriptions

Via l'app mobile TVO actuellement, on peut passer une commande Mondial Relay sans choisir de point relai. On peut également avoir une company renseignée par l'adresse de facturation (que l'on a pas en web).

Avec la PR de Loïc https://github.com/Wishibam/Ecommerce-sylius/pull/7439 on ne devrait plus exposer Mondial Relay pour l'app donc ça devrait empêcher ce problème.