### PR TITLE
fix: prevent caching the plugin javascript (safari issue)

### DIFF
--- a/src/Resources/views/list_shipping_method_with_mondial_relay_map.html.twig
+++ b/src/Resources/views/list_shipping_method_with_mondial_relay_map.html.twig
@@ -36,7 +36,7 @@
     {{ form_widget(form.parcelPoint) }}
 
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script type="text/javascript" src="https://widget.mondialrelay.com/parcelshop-picker/jquery.plugin.mondialrelay.parcelshoppicker.js"></script>
+    <script type="text/javascript" src="https://widget.mondialrelay.com/parcelshop-picker/jquery.plugin.mondialrelay.parcelshoppicker.js?{{ 'now'|date('U') }}"></script>
 
     {% if configuration.isGoogleType() %}
         <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{ configuration.googleApiKey }}"></script>


### PR DESCRIPTION
- **Trello:** https://trello.com/c/Af2TVYK4

## Description

Sur Safari, le widget s'affiche bien au premier chargement.
Ensuite si on fait un retour arrière, puis qu'on revient sur la page, on a une erreur :

```
TypeError: $map.MR_ParcelShopPicker is not a function
```

Visiblement Safari ne reload pas les fichiers dans le bon ordre avec cette suite d'action.